### PR TITLE
Fix document generation

### DIFF
--- a/src/Snap/Snaplet/Auth/Backends/MysqlSimple.hs
+++ b/src/Snap/Snaplet/Auth/Backends/MysqlSimple.hs
@@ -357,4 +357,3 @@ instance IAuthBackend MysqlAuthManager where
                 , " = ?"
                 ]
         authExecute pamConnPool q [userLogin]
-


### PR DESCRIPTION
There's a comment that Haddock disagrees with so no docs are being generated on Hackage.

See [Hackage build log](http://hackage.haskell.org/package/snaplet-mysql-simple-0.1.1.3/reports/1/log). 

The problem is that Haddock comments are only accepted in couple of places rather than everywhere.
